### PR TITLE
Consistency and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- TOC -->
 - [Introduction](#introduction)
-  - [KYC Background](#kyc-background)
+  - [Know Your Customer Background](#know-your-customer-background)
     - [Identity Verification](#identity-verification)
     - [IDV Vendor Integrations](#idv-vendor-integrations)
       - [PII Collected by IDV Vendor](#pii-collected-by-idv-vendor)
@@ -35,7 +35,7 @@
 # Introduction
 This document proposes a standardized means for PFIs (Participating Financial Institutions) to perform IDV (Identity Verification) on a DID (Decentralized Identifier) controlled by a retail customer for the purpose of providing financial services to that DID in accordance to regulatory Know Your Customer requirements.
 
-## KYC Background
+## Know Your Customer Background
 In the financial industry, KYC (Know Your Customer) is term used to describe a set of policies, procedures, and processes that financial institutions use to determine the true identity of a customer, and assess the on-going risk that a customer poses to an organization during the life-time of a customer relationship. KYC typically encompasses:
 * Customer identification and verification (IDV);
 * Understanding the nature and purpose of customer relationships to develop a customer risk profile; and


### PR DESCRIPTION
_Mobile Wallet_ instead of _DIDPay_
_IDV Vendor_ instead of _Vendor_
_SIOPV2 Authorization_ instead if _SIOPv2 Auth_

Mobile Wallet might be controversial. I think it would benefit the spec to be as generally applicable as possible, so shouldn't reference DIDPay. Maybe 'Wallet' doesn't describe all the tbDEX functionality it has though