### PR TITLE
prototype wallet selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The Web view is utilized to:
 > * establish a clear distinction between the application initiating the flow and a PFI
 
 
-## Initiating IDV Flow
+## IDV Flow without Wallet
 
 Initiating the IDV flow is done using [SIOPv2](https://openid.github.io/SIOPv2/openid-connect-self-issued-v2-wg-draft.html).
 
@@ -165,7 +165,7 @@ sequenceDiagram
 autonumber
 
 participant W as Webview
-participant D as Mobile Wallet
+participant D as Financial App
 participant P as PFI
 
 D->>+P: GET did:ex:pfi?service=IDV
@@ -182,12 +182,12 @@ D->>W: Load URL in IDV Request
 1. Mobile App resolves the PFI's DID and sends an HTTP GET Request to the `serviceEndpoint` of the first `IDV` service found in the resolved DID Document
 2. PFI constructs a [SIOPv2 Authorization Request](#siopv2-authorization-request)
 3. PFI URI encodes SIOPv2 Authorization Request and returns in HTTP response
-4. Mobile Wallet verifies integrity of SIOPv2 Authorization Request and constructs a [SIOPv2 Authorization Response](#siopv2-authorization-response)
-5. Mobile Wallet POSTs SIOPv2 Authorization Response to the `response_uri` from the SIOPv2 Authorization Request 
+4. Financial App verifies integrity of SIOPv2 Authorization Request and constructs a [SIOPv2 Authorization Response](#siopv2-authorization-response)
+5. Financial App POSTs SIOPv2 Authorization Response to the `response_uri` from the SIOPv2 Authorization Request 
 6. PFI verifies integrity of SIOPv2 Authorization Response and constructs IDV Request
 7. PFI returns IDV Request in HTTP response
-8. Mobile Wallet verifies integrity of IDV Request
-9. Mobile Wallet loads URL provided in IDV Request in Webview
+8. Financial App verifies integrity of IDV Request
+9. Financial App loads URL provided in IDV Request in Webview
 
 
 > [!WARNING]


### PR DESCRIPTION
[See modified README.md](https://github.com/tbdeng/known-customer-credential/blob/807ba36b23d6895b9ab8bff21dd129e61ac79e41/README.md)

the idea behind this is that wallet selection needs to occur somehow. for security OIDC and SIOP recommend using the system default browser, so that's where i'm doing wallet selection, and then passing it securely through a universal link