### PR TITLE
Fix KCC and KBC schema

### DIFF
--- a/schemas/kbc.schema.json
+++ b/schemas/kbc.schema.json
@@ -7,16 +7,20 @@
       "properties":{
         "id":{
           "type":"string",
-          "pattern":"^did:[a-z0-9]+:[a-zA-Z0-9.-_:]+$"
+          "pattern":"^did:[a-z0-9]+:([a-zA-Z0-9.-_:]|%[0-9A-Fa-f]{2})+$"
         }
       },
       "required":[
         "id"
       ]
     },
+    "id":{
+      "type":"string",
+      "format":"uri"
+    },
     "issuer":{
       "type":"string",
-      "pattern":"^did:[a-z0-9]+:[a-zA-Z0-9.-_:]+$"
+      "pattern":"^did:[a-z0-9]+:([a-zA-Z0-9.-_:]|%[0-9A-Fa-f]{2})+$"
     },
     "issuanceDate":{
       "type":"string",
@@ -27,25 +31,29 @@
       "format":"date-time"
     },
     "credentialSchema":{
-      "type":"object",
-      "properties":{
-        "id":{
-          "type":"string",
-          "format":"uri"
+      "type":"array",
+      "items":{
+        "type":"object",
+        "properties":{
+          "id":{
+            "type":"string",
+            "format":"uri"
+          },
+          "type":{
+            "type":"string",
+            "const":"JsonSchema"
+          }
         },
-        "type":{
-          "type":"string",
-          "const":"JsonSchema"
-        }
-      },
-      "required":[
-        "id",
-        "type"
-      ]
+        "required":[
+          "id",
+          "type"
+        ]
+      }
     }
   },
   "required":[
     "credentialSubject",
+    "id",
     "issuer",
     "issuanceDate",
     "expirationDate",

--- a/schemas/kbc.schema.json
+++ b/schemas/kbc.schema.json
@@ -32,6 +32,7 @@
     },
     "credentialSchema":{
       "type":"array",
+      "maxItems": 1,
       "items":{
         "type":"object",
         "properties":{

--- a/schemas/kcc.schema.json
+++ b/schemas/kcc.schema.json
@@ -7,7 +7,7 @@
          "properties":{
             "id":{
                "type":"string",
-               "pattern":"^did:[a-z0-9]+:[a-zA-Z0-9.-_:]+$"
+               "pattern":"^did:[a-z0-9]+:([a-zA-Z0-9.-_:]|%[0-9A-Fa-f]{2})+$"
             },
             "countryOfResidence":{
                "type":"string",
@@ -22,9 +22,13 @@
             "countryOfResidence"
          ]
       },
+      "id":{
+         "type":"string",
+         "format":"uri"
+      },
       "issuer":{
          "type":"string",
-         "pattern":"^did:[a-z0-9]+:[a-zA-Z0-9.-_:]+$"
+         "pattern":"^did:[a-z0-9]+:([a-zA-Z0-9.-_:]|%[0-9A-Fa-f]{2})+$"
       },
       "issuanceDate":{
          "type":"string",
@@ -35,21 +39,24 @@
          "format":"date-time"
       },
       "credentialSchema":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string",
-               "format":"uri"
+         "type":"array",
+         "items": {
+            "type": "object",
+            "properties": {
+               "id": {
+                  "type": "string",
+                  "format": "uri"
+               },
+               "type": {
+                  "type": "string",
+                  "const": "JsonSchema"
+               }
             },
-            "type":{
-               "type":"string",
-               "const":"JsonSchema"
-            }
-         },
-         "required":[
-            "id",
-            "type"
-         ]
+            "required": [
+               "id",
+               "type"
+            ]
+         }
       },
       "evidence":{
          "type":"array",
@@ -71,6 +78,7 @@
    },
    "required":[
       "credentialSubject",
+      "id",
       "issuer",
       "issuanceDate",
       "expirationDate",

--- a/schemas/kcc.schema.json
+++ b/schemas/kcc.schema.json
@@ -40,6 +40,7 @@
       },
       "credentialSchema":{
          "type":"array",
+         "maxItems": 1,
          "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
- Add `id` as required field
- Make `credentialSchema` expect an array
- Fix the regex for DID to allow for % encoded method specific parts, e.g. `did:web:localhost%3A8891`

Closes #42 